### PR TITLE
Adds :cxf variant to :into.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ A value-descriptor can be one of:
     - `:into`
         - `:coll`, collection to put values into
         - `:xf`, (optional) a transducer
+        - `:cxf`, (optional) a function that is passed the mapping context and 
+        returns transducer 
 
 Context options (can also be included in the mapping descriptor, context keys
 take precedence):


### PR DESCRIPTION
Adds :cxf key for use in the :into variant that passes the mapping context as an argument for cases where the transducer needs access to it. 